### PR TITLE
Fix mods not appearing on load

### DIFF
--- a/src/aohara/tinkertime/TinkerTime.java
+++ b/src/aohara/tinkertime/TinkerTime.java
@@ -59,11 +59,13 @@ public class TinkerTime {
 		frame.add(MenuFactory.createToolBar(mm), BorderLayout.NORTH);
 		frame.add(sp.getComponent(), BorderLayout.CENTER);
 		frame.add(pp.getComponent(), BorderLayout.SOUTH);
-		frame.pack();
-		frame.setVisible(true);
 
 		// Start Application
 		sm.getMods();  // Load mods (will notify selector panel)
+		
+		frame.pack();
+		frame.setVisible(true);
+		
 		try {
 			// Check for ModuleManager Update
 			if (config.autoUpdateModuleManager()){


### PR DESCRIPTION
Sometimes the mod list would appear empty because the frame was not repainted after loading all the mods and adding the components to the frame. This change should fix that by packing and rendering the frame _after_ loading mods.

Edit: Noticed this was already fixed in the 1.0 and profiles branches; feel free to close this.
