### PR TITLE
Center frame in screen

### DIFF
--- a/src/aohara/tinkertime/TinkerTime.java
+++ b/src/aohara/tinkertime/TinkerTime.java
@@ -68,6 +68,7 @@ public class TinkerTime {
 		frame.add(sp.getComponent(), BorderLayout.CENTER);
 		frame.add(pp.getComponent(), BorderLayout.SOUTH);
 		frame.pack();
+		frame.setLocationRelativeTo(null);
 		frame.setVisible(true);
 	}
 }


### PR DESCRIPTION
Super simple PR - This just centers the main window in the primary display on launch instead of it starting at the top left corner.
