### PR TITLE
Updates for custom version checker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'com.google.code.gson:gson:2.3'
     compile 'org.jsoup:jsoup:1.7.3'
-    compile 'com.github.zafarkhaja:java-semver:0.9.0'
 
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'org.mockito:mockito-all:1.9.5'

--- a/src/aohara/tinkertime/TinkerTime.java
+++ b/src/aohara/tinkertime/TinkerTime.java
@@ -22,7 +22,7 @@ import aohara.tinkertime.views.ModListCellRenderer;
 import aohara.tinkertime.views.ModView;
 import aohara.tinkertime.views.menus.MenuFactory;
 
-import com.github.zafarkhaja.semver.Version;
+import aohara.common.Version;
 
 /**
  * Main Class for Tinker Time

--- a/src/aohara/tinkertime/crawlers/Crawler.java
+++ b/src/aohara/tinkertime/crawlers/Crawler.java
@@ -40,13 +40,11 @@ public abstract class Crawler<T> implements Callable<Mod> {
 	
 	
 	public Crawler(URL url, PageLoader<T> pageLoader) {
-        System.out.printf("Url is %s\n", url.toString());
 		this.pageUrl = url;
 		this.pageLoader = pageLoader;
 	}
 	
 	public T getPage(URL url) throws IOException {
-        System.out.printf("getpage Url is %s\n", url.toString());
 		return pageLoader.getPage(url);
 	}
 	

--- a/src/aohara/tinkertime/crawlers/Crawler.java
+++ b/src/aohara/tinkertime/crawlers/Crawler.java
@@ -12,11 +12,10 @@ import java.util.concurrent.Callable;
 import javax.swing.JOptionPane;
 
 import aohara.common.VersionParser;
+import aohara.common.Version;
 import aohara.tinkertime.crawlers.pageLoaders.PageLoader;
 import aohara.tinkertime.models.Mod;
 
-import com.github.zafarkhaja.semver.UnexpectedCharacterException;
-import com.github.zafarkhaja.semver.Version;
 
 /**
  * Abstract Base Class for Creating Web Crawlers to gather file information.
@@ -41,11 +40,13 @@ public abstract class Crawler<T> implements Callable<Mod> {
 	
 	
 	public Crawler(URL url, PageLoader<T> pageLoader) {
+        System.out.printf("Url is %s\n", url.toString());
 		this.pageUrl = url;
 		this.pageLoader = pageLoader;
 	}
 	
 	public T getPage(URL url) throws IOException {
+        System.out.printf("getpage Url is %s\n", url.toString());
 		return pageLoader.getPage(url);
 	}
 	
@@ -71,12 +72,12 @@ public abstract class Crawler<T> implements Callable<Mod> {
 			// First try to parse version from an available version tag field
 			String versionString = VersionParser.parseVersionString(getVersionString());
 			return Version.valueOf(versionString);
-		} catch(UnexpectedCharacterException | IOException | IllegalArgumentException e){
+		} catch(IOException | IllegalArgumentException e){
 			try {
 				// Alternately, try to parse version from the fileName
 				String versionString = VersionParser.parseVersionString(getNewestFileName());
 				return Version.valueOf(versionString);
-			} catch (UnexpectedCharacterException | IOException | IllegalArgumentException e1) {
+			} catch (IOException | IllegalArgumentException e1) {
 				return null;
 			}
 		}

--- a/src/aohara/tinkertime/crawlers/JenkinsCrawler.java
+++ b/src/aohara/tinkertime/crawlers/JenkinsCrawler.java
@@ -9,9 +9,9 @@ import java.util.Date;
 import java.util.LinkedList;
 
 import aohara.common.VersionParser;
+import aohara.common.Version;
 import aohara.tinkertime.crawlers.pageLoaders.PageLoader;
 
-import com.github.zafarkhaja.semver.Version;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
@@ -31,6 +31,7 @@ public class JenkinsCrawler extends Crawler<JsonElement> {
 	@Override
 	public URL getApiUrl(){
 		try {
+            System.out.printf("apiurl: '%s'\n" ,String.format("%s/lastSuccessfulBuild/api/json", pageUrl));
 			return new URL(String.format("%s/lastSuccessfulBuild/api/json", pageUrl));
 		} catch (MalformedURLException e) {
 			throw new RuntimeException(e);

--- a/src/aohara/tinkertime/crawlers/JenkinsCrawler.java
+++ b/src/aohara/tinkertime/crawlers/JenkinsCrawler.java
@@ -31,7 +31,6 @@ public class JenkinsCrawler extends Crawler<JsonElement> {
 	@Override
 	public URL getApiUrl(){
 		try {
-            System.out.printf("apiurl: '%s'\n" ,String.format("%s/lastSuccessfulBuild/api/json", pageUrl));
 			return new URL(String.format("%s/lastSuccessfulBuild/api/json", pageUrl));
 		} catch (MalformedURLException e) {
 			throw new RuntimeException(e);

--- a/src/aohara/tinkertime/crawlers/UpdateCheckCrawler.java
+++ b/src/aohara/tinkertime/crawlers/UpdateCheckCrawler.java
@@ -5,7 +5,7 @@ import java.net.URL;
 import java.util.Date;
 import java.util.concurrent.Callable;
 
-import com.github.zafarkhaja.semver.Version;
+import aohara.common.Version;
 
 public class UpdateCheckCrawler implements Callable<Boolean> {
 	

--- a/src/aohara/tinkertime/models/Mod.java
+++ b/src/aohara/tinkertime/models/Mod.java
@@ -9,7 +9,7 @@ import aohara.common.VersionParser;
 import aohara.tinkertime.TinkerConfig;
 import aohara.tinkertime.crawlers.Crawler;
 
-import com.github.zafarkhaja.semver.Version;
+import aohara.common.Version;
 
 /**
  * Model for holding Mod information and status.

--- a/src/aohara/tinkertime/workflows/CheckForUpdateTask.java
+++ b/src/aohara/tinkertime/workflows/CheckForUpdateTask.java
@@ -7,7 +7,7 @@ import aohara.common.workflows.tasks.WorkflowTask;
 import aohara.tinkertime.crawlers.Crawler;
 import aohara.tinkertime.crawlers.UpdateCheckCrawler;
 
-import com.github.zafarkhaja.semver.Version;
+import aohara.common.Version;
 
 /**
  * Workflow Task that returns true if an update for a file is available.

--- a/src/aohara/tinkertime/workflows/DownloadModInBrowserTask.java
+++ b/src/aohara/tinkertime/workflows/DownloadModInBrowserTask.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 import javax.swing.JOptionPane;
 
-import com.github.zafarkhaja.semver.Version;
+import aohara.common.Version;
 
 import aohara.common.workflows.tasks.BrowserGoToTask;
 import aohara.common.workflows.tasks.WorkflowTask;

--- a/test/aohara/tinkertime/crawlers/AbstractTestGithubCrawler.java
+++ b/test/aohara/tinkertime/crawlers/AbstractTestGithubCrawler.java
@@ -32,7 +32,7 @@ public abstract class AbstractTestGithubCrawler extends AbstractTestModCrawler {
 			"api.github.com/repos/TriggerAu/KerbalAlarmClock/releases",
 			null,
 			null,
-			"3.2.30"
+			"3.2.3.0"
 		);
 	}
 	
@@ -47,7 +47,7 @@ public abstract class AbstractTestGithubCrawler extends AbstractTestModCrawler {
 			"api.github.com/repos/e-dog/ProceduralFairings/releases",
 			null,
 			null,
-			"3.11.0"
+			"3.11"
 		);
 	}
 	
@@ -97,7 +97,7 @@ public abstract class AbstractTestGithubCrawler extends AbstractTestModCrawler {
 			"api.github.com-repos-rbray89-ActiveTextureManagement",
 			null,
 			null,
-			"4.3.0"
+			"4.3"
 		);
 		
 	}

--- a/test/aohara/tinkertime/crawlers/TestCurseCrawler.java
+++ b/test/aohara/tinkertime/crawlers/TestCurseCrawler.java
@@ -21,7 +21,7 @@ public class TestCurseCrawler extends AbstractTestModCrawler {
 			"http://media-curse.cursecdn.com/attachments/thumbnails/"
 			+ "110/952/190/130/18b6dda728d709420f4b8959464e32ba.png",
 			"0.24.2",
-			"2.2.210"
+			"2.2.2.1.0"
 		);
 	}
 	
@@ -38,7 +38,7 @@ public class TestCurseCrawler extends AbstractTestModCrawler {
 			"http://media-curse.cursecdn.com/attachments/thumbnails/111/144/"
 			+ "190/130/46177821cf553bb4c8a15189f36d77f4.png",
 			"0.24.2",
-			"0.6.24"
+			"0.6.2.4"
 		);
 	}
 	
@@ -54,7 +54,7 @@ public class TestCurseCrawler extends AbstractTestModCrawler {
 			"http://media-curse.cursecdn.com/attachments/thumbnails/110/932/"
 			+ "190/130/313962a1a7206912f215151ea7f7b8d8.png",
 			"0.24.2",
-			"0.25.0"
+			"0.25"
 		);
 	}
 

--- a/test/aohara/tinkertime/crawlers/TestKerbalStuffCrawler.java
+++ b/test/aohara/tinkertime/crawlers/TestKerbalStuffCrawler.java
@@ -22,7 +22,7 @@ public class TestKerbalStuffCrawler extends AbstractTestModCrawler {
 			+ "20PanaTee%20Parts%20International/download/v0.30",
 			"https://kerbalstuff.com/1ATqqe1TChQV.png",
 			"0.24.2",
-			"0.30.0"
+			"0.30"
 		);
 	}
 	
@@ -37,7 +37,7 @@ public class TestKerbalStuffCrawler extends AbstractTestModCrawler {
 			"https://kerbalstuff.com/mod/21/Time%20Control/download/13.2",
 			"https://kerbalstuff.com/NSBC0_9jcVmk.png",
 			"0.24.2",
-			"13.2.0"
+			"13.2"
 		);
 	}
 


### PR DESCRIPTION
The current version checking code is broken for some mods on curseforge
http://www.curse.com/ksp-mods/kerbal/223730-kerbol-positioning-system
http://www.curse.com/ksp-mods/kerbal/220289-kerbal-alarm-clock

Since you are only using it to compare version numbers I have written some custom code that allows mods with versions that do not conform to the semver standard.

This is not just a compatibility request though. With the code used in VersionParser TinkerTime would mistakenly use old versions of mods under certain conditions:
old mod version: `<1.0.1.21>`
new mod version `<1.0.10.1>`
The code in VersionParser that made sure there are exactly 3 version numbers would create the following version strings:
`<1.0.121>`(old) and `<1.0.101>`(new)
This would cause the jsemver code to conclude that the old file is actually newer than the new file.

There is another pull request for the Common submodule that provides the actual Version checker code.

B.T.W: This change would close the following issue: https://github.com/oharaandrew314/TinkerTime/issues/221